### PR TITLE
use Official image

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,3 +1,3 @@
-FROM willnet/redash:latest
+FROM redash/redash:latest
 WORKDIR /app
 CMD /usr/local/bin/gunicorn -b 0.0.0.0:$PORT --name redash -w${REDASH_WEB_WORKERS:-1} redash.wsgi:app

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM willnet/redash:latest
+FROM redash/redash:latest
 
 ENV WORKERS_COUNT=${WORKERS_COUNT:-1}
 ENV QUEUES=${QUEUES:-celery}


### PR DESCRIPTION
I found redash Official image in DockerHub.
I think that it is better to use this, and I confirmed that it will move.