### PR TITLE
Introduce heroku.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 
 Dockerfiles for hosting redash on heroku
 
-## How to deploy
+## How to create
 
 ```sh
 git clone git@github.com:willnet/redash-on-heroku.git
 cd redash-on-heroku
-heroku create your_app_name
-heroku container:push --recursive
+heroku create --stack=container your_app_name
 ```
 
 ## How to setup
@@ -48,7 +47,7 @@ See also https://redash.io/help/open-source/setup#-setup
 ### Release container
 
 ```sh
-heroku container:release web worker
+git push heroku master
 ```
 
 ### Create database
@@ -69,8 +68,7 @@ heroku ps:scale worker=1
 
 ```sh
 heroku ps:scale web=0 worker=0
-heroku container:push --recursive
-heroku container:release web worker
+git push heroku master
 heroku run /app/manage.py db upgrade
 heroku ps:scale web=1 worker=1
 ```

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,4 @@
+build:
+  docker:
+    web: Dockerfile.web
+    worker: Dockerfile.worker


### PR DESCRIPTION
Hi @willnet,

[Building Docker Images with heroku.yml was Generally Available on Nov 13](https://blog.heroku.com/build-docker-images-heroku-yml). So I introduce heroku.yml to this repository.

You can easily review this PR according to README.md.

And you can easily switch from current redash on heroku.

    $ git remote add -f masutaka https://github.com/masutaka/redash-on-heroku.git
    $ git checkout introduce-heroku-yml
    $ git push heroku introduce-heroku-yml:master

FYI: [先週 GA になった、heroku.yml を使った Docker Deploy を試した / マスタカの ChangeLog メモ](https://masutaka.net/chalow/2018-11-21-1.html) (Japanese)

Thanks.
