### PR TITLE
Add REDASH_SECRET_KEY which is introduced from Redash v7.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Add environment variables like following.
 heroku config:set PYTHONUNBUFFERED=0
 heroku config:set QUEUES=queries,scheduled_queries,celery
 heroku config:set REDASH_COOKIE_SECRET=YOUR_SECRET_TOKEN
+heroku config:set REDASH_SECRET_KEY=YOUR_SECRET_KEY
 heroku config:set REDASH_DATABASE_URL=YOUR_POSTGRES_URL
 heroku config:set REDASH_LOG_LEVEL=INFO
 heroku config:set REDASH_REDIS_URL=YOUR_REDIS_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
       REDASH_LOG_LEVEL: "INFO"
       REDASH_REDIS_URL: "redis://redis:6379/0"
       REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
-      REDASH_COOKIE_SECRET: veryverysecret
+      REDASH_COOKIE_SECRET: veryverysecrettoken
+      REDASH_SECRET_KEY: veryverysecretkey
       REDASH_WEB_WORKERS: 4
   worker:
     build:


### PR DESCRIPTION
Although `REDASH_SECRET_KEY` is an optional environment variable, I have added it because they recommend it.

See also the belows;

:link: https://github.com/getredash/redash/releases/tag/v7.0.0

> This release adds encryption of your data sources configuration. By default it will use the `REDASH_COOKIE_SECRET` as encryption key. But we recommend setting a new key for it using the `REDASH_SECRET_KEY` environment variable. Note that you need to set this **before running migrations**. Otherwise everything will be encrypted with `REDSAH_COOKIE_SECRET`.

:link: [CHANGELOG.md](https://github.com/getredash/redash/blob/master/CHANGELOG.md#v700---2019-03-17)

> - **All data source options are now encrypted in the database.** By default the encryption uses the `REDASH_COOKIE_SECRET` value (`redash.settings.COOKIE_SECRET`), but you can specify a different value by setting the `REDASH_SECRET_KEY` environment variable value. Note that you need to set this _before_ doing the upgrade.