### PR TITLE
Add REDASH_ENFORCE_HTTPS which redirects http to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ heroku config:set REDASH_MAIL_SERVER=YOUR_ADDON_DOMAIN
 heroku config:set REDASH_MAIL_USERNAME=YOUR_ADDON_USERNAME
 heroku config:set REDASH_MAIL_USE_TLS=true
 heroku config:set REDASH_MAIL_DEFAULT_SENDER=YOUR_MAIL_ADDRESS
+heroku config:set REDASH_ENFORCE_HTTPS=true
 ```
 
 See also https://redash.io/help/open-source/setup#-setup

--- a/README.md
+++ b/README.md
@@ -30,18 +30,18 @@ Add environment variables like following.
 heroku config:set PYTHONUNBUFFERED=0
 heroku config:set QUEUES=queries,scheduled_queries,celery
 heroku config:set REDASH_COOKIE_SECRET=YOUR_SECRET_TOKEN
-heroku config:set REDASH_SECRET_KEY=YOUR_SECRET_KEY
 heroku config:set REDASH_DATABASE_URL=YOUR_POSTGRES_URL
-heroku config:set REDASH_LOG_LEVEL=INFO
-heroku config:set REDASH_REDIS_URL=YOUR_REDIS_URL
+heroku config:set REDASH_ENFORCE_HTTPS=true
 heroku config:set REDASH_HOST=YOUR_DOMAIN_URL
+heroku config:set REDASH_LOG_LEVEL=INFO
+heroku config:set REDASH_MAIL_DEFAULT_SENDER=YOUR_MAIL_ADDRESS
 heroku config:set REDASH_MAIL_PASSWORD=YOUR_ADDON_PASSWORD
 heroku config:set REDASH_MAIL_PORT=587
 heroku config:set REDASH_MAIL_SERVER=YOUR_ADDON_DOMAIN
 heroku config:set REDASH_MAIL_USERNAME=YOUR_ADDON_USERNAME
 heroku config:set REDASH_MAIL_USE_TLS=true
-heroku config:set REDASH_MAIL_DEFAULT_SENDER=YOUR_MAIL_ADDRESS
-heroku config:set REDASH_ENFORCE_HTTPS=true
+heroku config:set REDASH_REDIS_URL=YOUR_REDIS_URL
+heroku config:set REDASH_SECRET_KEY=YOUR_SECRET_KEY
 ```
 
 See also https://redash.io/help/open-source/setup#-setup


### PR DESCRIPTION
I just found `REDASH_ENFORCE_HTTPS` which redirects http://redash.example.com to https://redash.example.com.

I want to recommend it for security improvement.

https://redash.io/help/open-source/admin-guide/env-vars-settings
https://github.com/getredash/redash/blob/v7.0.0/redash/settings/__init__.py#L53
